### PR TITLE
fix(intro): removed useless description - legacy

### DIFF
--- a/content/0_introduction/_index.en.md
+++ b/content/0_introduction/_index.en.md
@@ -5,18 +5,6 @@ chapter: true
 draft: false
 ---
 
-# Intorduction
-
-You can learn belows through this workshop:
-
-- Network infrastructure for containers
-- Container image build tool
-- Container application deployment
-- Observability for containerized application (Metrics, Logs, Trace)
-- Container deployment strategy
-- Service Mesh for traffic management of distibuted and complex microservices.
-- 안전한 배포를 위하여 서비스 매시의 트래픽 제어 기능을 활용하는 방법을 학습합니다.
-- 인프라스트럭처를 코드로 관리하는 방법을 학습합니다.
-- 인프라스트럭처 코드를 재사용하여 생산성과 가독성을 높이는 방법을 학습합니다.
+# Intorduction to Chaos Engineering
 
 {{% children showhidden="true" %}}

--- a/content/0_introduction/_index.ko.md
+++ b/content/0_introduction/_index.ko.md
@@ -4,6 +4,7 @@ weight: 5
 chapter: true
 draft: false
 ---
+
 # 카오스 엔지니어링 소개
 
 {{% children showhidden="true" %}}


### PR DESCRIPTION
모듈에서 템플릿으로 사용하던 `Well-Architected Containers with DevOps` 의 내용을 `카오스 엔지니어링 소개` 부분에서 제거 하였습니다.