### PR TITLE
chore(workspace): workspace setup chapter title naming

### DIFF
--- a/content/20_ec2/00_setup/_index.ko.md
+++ b/content/20_ec2/00_setup/_index.ko.md
@@ -1,11 +1,11 @@
 ---
-title: "실습 환경 준비하기"
+title: "실습 환경 준비"
 weight: 1
 chapter: true
 draft: false
 ---
 
-# 실습 환경 준비하기
+# 실습 환경 준비
 
 준비과정을 마치면 실습을 위해 간단하게 구현된 아래의 데모 애플리케이션이 배포됩니다.
 ![image](/images/20_ec2/architecture.png)

--- a/content/30_eks/00_setup/_index.ko.md
+++ b/content/30_eks/00_setup/_index.ko.md
@@ -1,10 +1,10 @@
 ---
-title: "실습 환경 준비하기"
+title: "실습 환경 준비"
 weight: 01
 chapter: true
 draft: false
 ---
 
-# 실습 환경 준비하기
+# 실습 환경 준비
 
 {{% children showhidden="true" %}}


### PR DESCRIPTION
사소한 것이지만, 타이틀의 통일감을 위해서 수정하였습니다. '실습 환경 정리' 와 맞추기 위해서 '실습 환경 준비하기'를 '실습 환경 준비' 로 변경합니다. 